### PR TITLE
Make input event listeners optional

### DIFF
--- a/examples/RadioButton.client.lua
+++ b/examples/RadioButton.client.lua
@@ -20,8 +20,14 @@ local test = Roact.createElement(RoactMaterial.ThemeProvider, {
             });
             Roact.createElement(RoactMaterial.RadioButton, {
                 Checked = true;
+                onClicked = function()
+					print('RadioButton clicked')
+                end;
             });
             Roact.createElement(RoactMaterial.RadioButton, {
+                onClicked = function()
+					print('RadioButton clicked')
+                end;
             });
         })
     })

--- a/src/Components/Checkbox.lua
+++ b/src/Components/Checkbox.lua
@@ -60,7 +60,9 @@ function Checkbox:render()
             Text = "";
 
             [Roact.Event.MouseButton1Click] = function(rbx)
-                self.props.onChecked(not self.props.Checked)
+                if self.props.onChecked then
+					self.props.onChecked(not self.props.Checked)
+				end;
             end;
         }, {
             c(Icon, {

--- a/src/Components/Checkbox.lua
+++ b/src/Components/Checkbox.lua
@@ -34,8 +34,8 @@ function Checkbox:willUpdate(nextProps, nextState)
             table.insert(animations, RoactAnimate.Sequence({
                 RoactAnimate.Prepare(self.state._rippleSize, UDim2.new(0, 0, 0, 0)),
                 RoactAnimate.Prepare(self.state._rippleTransparency, 0.6),
-                RoactAnimate(self.state._rippleSize, TweenInfo.new(0.15), UDim2.new(1.75, 0, 1.75, 0)),
-                RoactAnimate(self.state._rippleTransparency, TweenInfo.new(0.15), 1)
+                RoactAnimate(self.state._rippleSize, TweenInfo.new(0.25, Enum.EasingStyle.Sine), UDim2.new(1.75, 0, 1.75, 0)),
+                RoactAnimate(self.state._rippleTransparency, TweenInfo.new(.08, Enum.EasingStyle.Quart, Enum.EasingDirection.InOut), 1)
             }))
         end
     end

--- a/src/Components/Checkbox.lua
+++ b/src/Components/Checkbox.lua
@@ -61,8 +61,8 @@ function Checkbox:render()
 
             [Roact.Event.MouseButton1Click] = function(rbx)
                 if self.props.onChecked then
-					self.props.onChecked(not self.props.Checked)
-				end;
+                    self.props.onChecked(not self.props.Checked)
+                end;
             end;
         }, {
             c(Icon, {

--- a/src/Components/RadioButton.lua
+++ b/src/Components/RadioButton.lua
@@ -69,7 +69,9 @@ function RadioButton:render()
             Text = "";
 
             [Roact.Event.MouseButton1Click] = function(rbx)
-                self.props.onClicked()
+                if self.props.onClicked then
+					self.props.onClicked()
+			    end;
             end;
         }, {
             c(Icon, {

--- a/src/Components/RadioButton.lua
+++ b/src/Components/RadioButton.lua
@@ -70,8 +70,8 @@ function RadioButton:render()
 
             [Roact.Event.MouseButton1Click] = function(rbx)
                 if self.props.onClicked then
-					self.props.onClicked()
-			    end;
+                    self.props.onClicked()
+                end;
             end;
         }, {
             c(Icon, {

--- a/src/Components/RadioButton.lua
+++ b/src/Components/RadioButton.lua
@@ -45,8 +45,8 @@ function RadioButton:willUpdate(nextProps, nextState)
         table.insert(animations, RoactAnimate.Sequence({
             RoactAnimate.Prepare(self.state._rippleSize, UDim2.new(0, 0, 0, 0)),
             RoactAnimate.Prepare(self.state._rippleTransparency, 0.6),
-            RoactAnimate(self.state._rippleSize, TweenInfo.new(0.15), UDim2.new(1.75, 0, 1.75, 0)),
-            RoactAnimate(self.state._rippleTransparency, TweenInfo.new(0.15), 1)
+            RoactAnimate(self.state._rippleSize, TweenInfo.new(0.25, Enum.EasingStyle.Sine), UDim2.new(1.75, 0, 1.75, 0)),
+            RoactAnimate(self.state._rippleTransparency, TweenInfo.new(.08, Enum.EasingStyle.Quart, Enum.EasingDirection.InOut), 1)
         }))
     end
 

--- a/src/Components/Switch.lua
+++ b/src/Components/Switch.lua
@@ -40,8 +40,8 @@ function Switch:willUpdate(nextProps, nextState)
                 RoactAnimate.Prepare(self.state._rippleSize, UDim2.new(0, 0, 0, 0)),
                 RoactAnimate.Prepare(self.state._rippleTransparency, 0.6),
                 RoactAnimate.Prepare(self.state._rippleColor, newRippleColor),
-                RoactAnimate(self.state._rippleSize, TweenInfo.new(0.15), UDim2.new(1.75, 0, 1.75, 0)),
-                RoactAnimate(self.state._rippleTransparency, TweenInfo.new(0.15), 1)
+                RoactAnimate(self.state._rippleSize, TweenInfo.new(0.25, Enum.EasingStyle.Sine), UDim2.new(1.75, 0, 1.75, 0)),
+                RoactAnimate(self.state._rippleTransparency, TweenInfo.new(.08, Enum.EasingStyle.Quart, Enum.EasingDirection.InOut), 1)
             })
         }):Start()
     end

--- a/src/Components/Switch.lua
+++ b/src/Components/Switch.lua
@@ -56,7 +56,9 @@ function Switch:render()
         ZIndex = self.props.ZIndex;
 
         [Roact.Event.MouseButton1Click] = function(rbx)
-            self.props.onChecked(not self.props.Checked)
+            if self.props.onChecked then
+				self.props.onChecked(not self.props.Checked)
+			end;
         end;
     }, {
         Track = c(RoactAnimate.ImageLabel, {

--- a/src/Components/Switch.lua
+++ b/src/Components/Switch.lua
@@ -57,8 +57,8 @@ function Switch:render()
 
         [Roact.Event.MouseButton1Click] = function(rbx)
             if self.props.onChecked then
-				self.props.onChecked(not self.props.Checked)
-			end;
+                self.props.onChecked(not self.props.Checked)
+            end;
         end;
     }, {
         Track = c(RoactAnimate.ImageLabel, {


### PR DESCRIPTION
Not listening for either onClicked or onChecked throws nil value errors. Listeners should be optional and not halt execution. 

Double commits because roact-material is using spaces instead of tabs.